### PR TITLE
include netinet/in.h

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -1,5 +1,6 @@
 #include <netdb.h>
 #include <netinet/tcp.h>
+#include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
 #include <sys/types.h>


### PR DESCRIPTION
FreeBSD is not finding IPPROTO_TCP identifier without netinet/in.h

```
[kandy@freebsd ~]$ gem install trilogy
Building native extensions. This could take a while... ERROR:  Error installing trilogy:
        ERROR: Failed to build gem native extension.

    current directory: /usr/home/kandy/.gem/ruby/3.2.2/gems/trilogy-2.4.1/ext/trilogy-ruby
/usr/home/kandy/.rubies/ruby-3.2.2/bin/ruby extconf.rb checking for CRYPTO_malloc() in -lcrypto... yes
checking for SSL_new() in -lssl... yes
checking for rb_interned_str() in ruby.h... yes
creating Makefile

current directory: /usr/home/kandy/.gem/ruby/3.2.2/gems/trilogy-2.4.1/ext/trilogy-ruby make DESTDIR\= sitearchdir\=./.gem.20230603-79859-at41zf sitelibdir\=./.gem.20230603-79859-at41zf clean

current directory: /usr/home/kandy/.gem/ruby/3.2.2/gems/trilogy-2.4.1/ext/trilogy-ruby make DESTDIR\= sitearchdir\=./.gem.20230603-79859-at41zf sitelibdir\=./.gem.20230603-79859-at41zf compiling trilogy.c
trilogy.c:2744:38: error: use of undeclared identifier 'IPPROTO_TCP'
            if (setsockopt(sock->fd, IPPROTO_TCP, TCP_KEEPIDLE, (void *)&flags, sizeof(flags)) < 0) {
                                     ^
trilogy.c:2752:38: error: use of undeclared identifier 'IPPROTO_TCP'
            if (setsockopt(sock->fd, IPPROTO_TCP, TCP_KEEPINTVL, (void *)&flags, sizeof(flags)) < 0) {
                                     ^
trilogy.c:2760:38: error: use of undeclared identifier 'IPPROTO_TCP'
            if (setsockopt(sock->fd, IPPROTO_TCP, TCP_KEEPCNT, (void *)&flags, sizeof(flags)) < 0) {
                                     ^
3 errors generated.
*** Error code 1

Stop.
make: stopped in /usr/home/kandy/.gem/ruby/3.2.2/gems/trilogy-2.4.1/ext/trilogy-ruby

make failed, exit code 1

Gem files will remain installed in /usr/home/kandy/.gem/ruby/3.2.2/gems/trilogy-2.4.1 for inspection. Results logged to /usr/home/kandy/.gem/ruby/3.2.2/extensions/x86_64-freebsd-13/3.2.0-static/trilogy-2.4.1/gem_make.out
```